### PR TITLE
feat: add additional support for datacenter editions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ conkeyscan -url 'https://example.atlassian.net'  --username 'ex@amp.le' --passwo
 
 To create an API key in the cloud go to: https://id.atlassian.com/manage-profile/security/api-tokens.
 
-If testing against OnPrem instance you can create an API key in the user settings.
+If testing against OnPrem instance you can create an API key in the user settings (and use conkeyscan with the parameter `-on-prem-pat` or `-t` for certain versions).
 
 # Dictionary
 
@@ -47,6 +47,7 @@ The default `dict.txt` file was taken from from [Conf-Thief](https://raw.githubu
 * Proxying is supported either via HTTP or socks. See cli help for examples
 * Custom CQL
 * SSL/TLS checks are disabled by default
+* Supports cloud- and datacenter/server editions
 
 # Alternatives 
 

--- a/src/conkeyscan/conkeyscan.py
+++ b/src/conkeyscan/conkeyscan.py
@@ -133,6 +133,7 @@ def main(
     url: "u",
     username: "usr",
     password: "pwd",
+    on_prem_pat: "t" = False,
     dict_path: "d" = str(files("conkeyscan.config").joinpath("dict.txt")),
     disable_ssl_checks: "k" = True,
     rate_limit: "r" = 100,
@@ -146,6 +147,7 @@ def main(
     :param url: URL of the Confluence instance
     :param username: The username of the account to be used
     :param password: The according password OR an API key!
+    :param on_prem_pat: Flag indicating whether to use PAT (Personal Access Token) for authentication instead of password [Data center / server editions only!]
     :param dict_path: The path to the dictionary file containing the keywords to search for, falls back to included dict
     :param cql: A custom CQL query which must include KEYWORD_PLACEHOLDER at least once in the string which will be replaced by the keyword
     :param disable_ssl_checks: Specify whether to verify SSL/TLS certificates
@@ -186,13 +188,23 @@ def main(
         "conkeyscan_results_" + datetime.now().strftime("%Y_%m_%d_%H_%M") + ".log"
     )
 
-    confluence_client = Confluence(
-        url=url,
-        username=username,
-        password=password,
-        verify_ssl=not disable_ssl_checks,
-        session=rate_limited_session,
-    )
+    confluence_client = None
+
+    if on_prem_pat:
+        confluence_client = Confluence(
+            url=url,
+            token=password,
+            verify_ssl=not disable_ssl_checks,
+            session=rate_limited_session,
+        )
+    else:
+        confluence_client = Confluence(
+            url=url,
+            username=username,
+            password=password,
+            verify_ssl=not disable_ssl_checks,
+            session=rate_limited_session,
+        )
 
     keywords = []
     try:


### PR DESCRIPTION
# Initial Situation

The authentication for data center editions is currently not working (Error 401).

According to the [Atlassian Python API](https://atlassian-python-api.readthedocs.io/), the login method changes for data center editions. Instead of username/password, the API only expects a token (The information on the documentation that this only applies to versions < 7.9 is not correct).

# Changes

- A new parameter `-on-prem-pat` / `-t` has been added.
- The instantiation of `confluence_client` has been adjusted depending on whether the parameter `-on-prem-pat` / `-t` was set or not.
- Documentation has been updated.

# Testing
Functionality has been successfully tested with Confluence data center edition 8.5.11.